### PR TITLE
Removed unnecessary constructor

### DIFF
--- a/src/lpegj/luaj/lpeg.java
+++ b/src/lpegj/luaj/lpeg.java
@@ -226,9 +226,6 @@ public class lpeg extends VarArgFunction {
 
     static LuaValue pattmeta;
 
-    public lpeg() {
-    }
-
     Pattern pattP(LuaValue arg) {
         if (arg.isuserdata(Pattern.class))
             return (Pattern) arg.touserdata(Pattern.class);


### PR DESCRIPTION
[According to the docs:](http://docs.oracle.com/javase/specs/jls/se7/html/jls-8.html#jls-8.8.9)

> If a class contains no constructor declarations, then a default constructor with no formal parameters and no throws clause is implicitly declared.

Therefore, you shouldn't need an empty constructor.
